### PR TITLE
Repair build for current compilers

### DIFF
--- a/attach.c
+++ b/attach.c
@@ -96,7 +96,7 @@ die(int sig)
 
 /* Window size change. */
 static RETSIGTYPE
-win_change()
+win_change(int sig)
 {
 	signal(SIGWINCH, win_change);
 	win_changed = 1;


### PR DESCRIPTION
When building against a modern GCC I get

> attach.c:202:26: error: passing argument 2 of ‘signal’ from incompatible pointer type [-Wincompatible-pointer-types]
> /usr/include/signal.h:88:57: note: expected ‘__sighandler_t’ {aka ‘void (*)(int)’} but argument is of type ‘void (*)(void)’

this fixes the build (and, what I care about, fixes https://aur.archlinux.org/packages/dtach-ng :) )